### PR TITLE
Fix the TB size for gaussian 

### DIFF
--- a/benchmarks/src/cuda/rodinia/3.1/cuda/gaussian/Makefile
+++ b/benchmarks/src/cuda/rodinia/3.1/cuda/gaussian/Makefile
@@ -7,6 +7,8 @@ INCLUDE := $(CUDA_DIR)/include
 SRC = gaussian.cu
 EXE = gaussian
 
+KERNEL_DIM := -DRD_WG_SIZE_0=128 -DRD_WG_SIZE_1=16
+
 release: $(SRC)
 	$(CC) $(KERNEL_DIM) $(SRC) -o $(EXE) -I$(INCLUDE) -L$(CUDA_LIB_DIR) -lcudart 
 


### PR DESCRIPTION
Gaussian uses variables set at compile-time for block/grid dimensions calculations. Currently these are not being set, and defaulting to 4x4 TBs.